### PR TITLE
Don't block the event loop on context end and related fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/dop251/goja v0.0.0-20231027120936-b396bb4c349d
 	github.com/mstoykov/k6-taskqueue-lib v0.1.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	go.k6.io/k6 v0.48.0
 )
@@ -29,7 +30,6 @@ require (
 	github.com/onsi/gomega v1.20.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect


### PR DESCRIPTION
Previously setTimeout (and co) might block the event loop in cases where
timeout hasn't triggered but the context has been done.

While fixing that some other potential races were found. Most of them
due to trying to write less code - but it is actually important that if
we are using the event loop we do all the stuff on it.

Additionally fixing a panic in init context if a timer gets interrupted -
 all due to using the logger from the lib.State.

The test added did tease out a bunch of this issues, and does reproduce
the original issue *on* occasion. Unfortunately a better reproducible
test seems to be very hard to write